### PR TITLE
Model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Graceful handling of discovery failures (network errors, missing credentials) without aborting configuration
 - `allow_dummy_key_endpoints` in `~/.config/rosie/config.toml` to explicitly allow dummy-key fallback for non-local endpoints
 - `--configure` prompt for dummy-key fallback endpoints (comma-separated host, host:port, or URL entries)
+- On model discovery failure, `--configure` now prompts whether to continue without discovery or exit
 
 ### Changed  
 - `--configure` now includes automatic model discovery instead of always prompting for a hardcoded default

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ short summary, and let you choose to execute it, re-enter your prompt, or quit.
 During `--configure`, after setting the endpoint, Rosie automatically discovers 
 available models from the API (if authenticated) and presents them in a numbered list.
 You can select by number, enter the full model ID, or press Enter to keep the current/default value.
-If discovery fails due to network issues or missing credentials, it falls back gracefully without interrupting configuration.
+If discovery fails (for example due to connection issues or missing credentials),
+Rosie prompts you to continue without discovery or exit configuration.
 
 In `--chat` / `-c` mode, Rosie answers questions naturally without command generation.
 Chat mode is non-interactive - it simply prints the answer once and exits. No execute

--- a/man/rosie.1
+++ b/man/rosie.1
@@ -31,7 +31,8 @@ Non-interactive mode prints the command and summary and then exits.
 .B \-\-configure
 Interactively create or update the local configuration file. The command now performs 
 automatic model discovery after setting the endpoint. When discovered, you can select from 
-available models by number or full ID; if discovery fails, a default model is used instead.
+available models by number or full ID; if discovery fails, you can choose to
+continue without discovery or exit configuration.
 .TP
 .B \-\-install
 Install the current binary into the local bin directory and install this man
@@ -62,6 +63,10 @@ Recognized environment variables:
 .B ROSIE_API_KEY
 API key for the OpenAI-compatible endpoint. Required for non-local endpoints.
 For localhost endpoints, Rosie falls back to a built-in dummy key if unset.
+For remote endpoints, dummy-key fallback applies only when the endpoint is
+allowlisted in
+.I allow_dummy_key_endpoints
+in the config file.
 .TP
 .B ROSIE_ENDPOINT
 Base endpoint URL. Defaults to

--- a/src/main.rs
+++ b/src/main.rs
@@ -759,15 +759,23 @@ async fn configure() -> Result<()> {
                     None
                 }
             }
-            Err(_) => {
-                // Discovery failed (network error, API error), keep current config model value
-                println!("Model discovery unavailable. Using the default model.");
-                None
+            Err(err) => {
+                // Discovery failed (network/API/etc.), keep current config model value
+                let message = format!("Model discovery failed: {}", err);
+                if prompt_continue_or_exit(&message)? {
+                    None
+                } else {
+                    return Ok(());
+                }
             }
         },
         Err(err) => {
-            println!("Model discovery unavailable: {}", err);
-            None
+            let message = format!("Model discovery unavailable: {}", err);
+            if prompt_continue_or_exit(&message)? {
+                None
+            } else {
+                return Ok(());
+            }
         }
     };
 
@@ -841,6 +849,30 @@ fn parse_csv_list(value: String) -> Option<Vec<String>> {
         None
     } else {
         Some(values)
+    }
+}
+
+fn prompt_continue_or_exit(reason: &str) -> Result<bool> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Ok(true);
+    }
+
+    println!("{}", reason);
+    println!("Continue without model discovery?");
+
+    loop {
+        let choice = prompt_config_value("[c]ontinue or [e]xit", Some("c"), true)?;
+        let normalized = choice.trim().to_ascii_lowercase();
+
+        if normalized.is_empty() || normalized == "c" || normalized == "continue" {
+            return Ok(true);
+        }
+
+        if normalized == "e" || normalized == "exit" {
+            return Ok(false);
+        }
+
+        println!("Please enter 'c' to continue or 'e' to exit.");
     }
 }
 


### PR DESCRIPTION
  - Added --version / -V and --model <MODEL> CLI flags.
  - Improved --configure with automatic model discovery and interactive model selection (number or full model ID).
  - Added graceful discovery failure handling with explicit user choice to continue without discovery or exit.
  - Renamed environment variables from OPENAI_* to ROSIE_* (ROSIE_API_KEY, ROSIE_ENDPOINT, ROSIE_MODEL).
      - Breaking: no compatibility fallback for OPENAI_*.
  - Switched API key handling to environment-only (ROSIE_API_KEY); keys are no longer read/stored in config.toml.
      - Breaking: existing config.toml api_key is ignored.
  - Added allow_dummy_key_endpoints in config.toml to explicitly allow dummy-key fallback for non-local OpenAI-compatible endpoints.
  - Updated dummy-key behavior:
      - localhost endpoints fallback automatically
      - remote endpoints fallback only when allowlisted
  - Removed persistent api_key storage from ~/.config/rosie/config.toml.
  - Updated README/man docs to reflect all of the above configuration and fallback changes.