### PR TITLE
Codex native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- Reinterpreted `type = "openai"` as native ChatGPT-backed auth/runtime via the local OpenAI CLI, including new `rosie auth login|logout openai` commands
+- Moved OpenAI API-key usage to named `openai-compatible` providers and reject legacy `openai` configs that still set `endpoint`
+- Deprecated `rosie auth add|remove openai` in favor of native login, while keeping keychain auth for Anthropic and named `openai-compatible` providers
+- Added built-in native OpenAI model presets for `--config` and the TUI model picker, while keeping manual model entry available as an escape hatch; the current validated ChatGPT-backed set is `gpt-5-codex` and `gpt-5`
+- Documented that native `openai` follows ChatGPT/Codex limits and that `openai-compatible` with the official OpenAI endpoint is the API-key path that may incur standard API billing
+
 ## 0.9.0
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,6 +2517,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 anyhow = "1"
 log = "0.4"
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["io-std", "io-util", "macros", "process", "rt-multi-thread"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Running `rosie` with no mode flag launches the full-screen TUI chat interface (l
 - `--model <MODEL>` runtime model override for `--ask`, `--cmd`, and TUI launch
 - Provider-driven model defaults in `~/.config/rosie/config.toml`
 - Interactive `--config` flow with provider-aware setup
-- `rosie auth add|list|remove` for API-key management
+- `rosie auth login|logout|list` for native OpenAI auth and `auth add|remove` for API-key providers
 - Local install helper via `rosie --install`
 - Cross-platform Rust binary (Linux/macOS/Windows with Rust toolchain)
 
-Rosie now routes `--ask`, `--cmd`, and TUI chat through Ollama, OpenAI, Anthropic, and OpenAI-compatible providers.
+Rosie now routes `--ask`, `--cmd`, and TUI chat through Ollama, native OpenAI, Anthropic, and OpenAI-compatible providers.
 
 ## Installation
 
@@ -52,8 +52,10 @@ rosie
 # Configure Rosie provider settings
 rosie --config
 
-# Store an API key in the OS keychain
-rosie auth add openai
+# Log in to native OpenAI / ChatGPT
+rosie auth login openai
+
+# Store API keys for API-backed providers
 rosie auth add anthropic
 rosie auth add local
 
@@ -110,6 +112,7 @@ In the default TUI:
 - in session manager, use `j`/`k` to select and `Enter` switch, `n` new, `r` rename, `d` delete (with confirmation), `Esc` close
 - delete actions require confirmation (`[Y/n]`; `Enter` defaults to `Y`)
 - in the model picker, use `j`/`k` (or arrows) to move when discovery is available; otherwise type a model name directly, then press `Enter` to apply or `Esc` to cancel
+- native `openai` uses built-in model presets in the picker and supports `i` to switch to manual model entry
 - selected models are persisted per session and restored when you switch sessions/restart
 - press `Esc` in `Normal` to cancel an in-flight request
 - `Ctrl+C` quits from any mode
@@ -139,13 +142,14 @@ That command creates/updates config and prompts for:
 - one provider block under `[providers.<name>]`
 - `execution_enabled` (controls whether execute is allowed in `--cmd`)
 
-Credential resolution order:
-1. environment variable
-2. OS keychain via `rosie auth add <provider>`
-3. error
+Authentication:
+- native `openai` uses `rosie auth login openai` / `rosie auth logout openai`
+- native `openai` uses the local Codex CLI with your ChatGPT login, so usage follows ChatGPT/Codex limits rather than OpenAI API-key billing
+- API-backed providers resolve credentials from environment variables first and then the OS keychain
+- key-based providers use `rosie auth add <provider>` and `rosie auth remove <provider>`
+- `openai-compatible` with `https://api.openai.com/v1` is the API path and may incur standard OpenAI API charges
 
-Credential environment variables:
-- `OPENAI_API_KEY`
+Credential environment variables for API-backed providers:
 - `ANTHROPIC_API_KEY`
 - `ROSIE_<PROVIDER_NAME>_API_KEY` for named `openai-compatible` providers
 
@@ -166,6 +170,24 @@ endpoint = "http://localhost:11434"
 model = "llama3.2"
 ```
 
+Example native OpenAI config:
+
+```toml
+active_provider = "openai"
+
+[providers.openai]
+type = "openai"
+model = "gpt-5-codex"
+```
+
+Built-in native OpenAI model presets currently include:
+- `gpt-5-codex`
+- `gpt-5`
+
+These are the currently validated model IDs for the ChatGPT-backed Codex path Rosie uses. Other ChatGPT or API model names may be rejected by Codex even if they exist elsewhere in OpenAI's product lineup.
+
+You can still type another model name manually in the TUI model picker by pressing `i`, but Rosie treats that as an advanced override and Codex may reject it for ChatGPT-backed usage.
+
 Example OpenAI-compatible config:
 
 ```toml
@@ -177,6 +199,19 @@ endpoint = "http://192.168.1.20:8080/v1"
 model = "omnicoder-9b"
 allow_insecure_http = false
 ```
+
+OpenAI API access now uses `openai-compatible`. Example:
+
+```toml
+active_provider = "oai-http"
+
+[providers.oai-http]
+type = "openai-compatible"
+endpoint = "https://api.openai.com/v1"
+model = "gpt-5"
+```
+
+Use the API-backed `openai-compatible` path when you specifically want OpenAI API-key billing/quotas instead of ChatGPT/Codex-native usage.
 
 Theme file schema (preferred):
 
@@ -229,7 +264,8 @@ Model resolution order:
 If no model can be resolved, Rosie exits with an actionable error.
 
 Remote transport rules:
-- OpenAI and Anthropic endpoints must use HTTPS
+- native `openai` uses the local OpenAI CLI login/runtime and does not accept `endpoint`
+- Anthropic endpoints must use HTTPS
 - OpenAI-compatible endpoints may use plain HTTP on `localhost`, loopback IPs, and `192.168.x.x`
 - other non-HTTPS OpenAI-compatible endpoints require `allow_insecure_http = true`
 

--- a/docs/current-runtime-and-tui-spec.md
+++ b/docs/current-runtime-and-tui-spec.md
@@ -29,8 +29,19 @@ Current provider scope:
   - `execution_enabled`
 - Auth commands:
   - `rosie auth add <provider>`
+  - `rosie auth login <provider>`
   - `rosie auth list`
+  - `rosie auth logout <provider>`
   - `rosie auth remove <provider>`
+- Native auth:
+  - `openai` uses native CLI login via `rosie auth login openai`
+  - native `openai` follows ChatGPT/Codex usage limits rather than OpenAI API-key billing
+  - OpenAI API access now uses a named `openai-compatible` provider
+  - the OpenAI API path may incur standard API billing
+- Native OpenAI model selection:
+  - built-in validated presets are used in `--config` and the TUI model picker
+  - the current validated ChatGPT-backed set is `gpt-5-codex` and `gpt-5`
+  - the TUI model picker supports switching to manual entry
 - Model resolution order:
   1. `--model`
   2. active provider config `model`

--- a/man/rosie.1
+++ b/man/rosie.1
@@ -169,13 +169,19 @@ Display version information and exit.
 Print help information.
 .TP
 .B rosie auth add
-Store a provider API key in the OS keychain.
+Store a provider API key in the OS keychain for key-based providers.
+.TP
+.B rosie auth login
+Start native provider login. OpenAI uses the local Codex CLI login flow.
 .TP
 .B rosie auth list
-Show whether provider credentials are available from environment variables or keychain storage.
+Show native login state and whether key-based provider credentials are available from environment variables or keychain storage.
+.TP
+.B rosie auth logout
+Remove native provider login state.
 .TP
 .B rosie auth remove
-Delete a provider API key from the OS keychain.
+Delete a provider API key from the OS keychain for key-based providers.
 .SH CONFIGURATION
 Rosie uses file-based configuration:
 .TP
@@ -230,14 +236,29 @@ active provider
 .IP "3." 4
 first provider-discovered model when supported
 .PP
-API keys resolve from provider-specific environment variables first and then the OS keychain. OpenAI uses
-.BR OPENAI_API_KEY ,
-Anthropic uses
+Native
+.B openai
+uses
+.BR "rosie auth login openai" ,
+which delegates to the local Codex CLI and follows ChatGPT/Codex limits rather than OpenAI API-key billing.
+API keys resolve from provider-specific environment variables first and then the OS keychain. Anthropic uses
 .BR ANTHROPIC_API_KEY ,
 and named compatible providers use
 .BR ROSIE_<PROVIDER_NAME>_API_KEY .
 .PP
-OpenAI and Anthropic endpoints must use HTTPS. OpenAI-compatible endpoints may use plain HTTP on localhost, loopback IPs, and
+Native
+.B openai
+does not accept
+.BR endpoint .
+The validated ChatGPT-backed native model set currently includes
+.BR gpt-5-codex " and " gpt-5 .
+Other model names may be rejected by Codex even if they exist in OpenAI's API or ChatGPT product lineup.
+.PP
+Use
+.B openai-compatible
+with the official OpenAI endpoint when you want API-key billing and quotas instead of ChatGPT/Codex-native usage.
+.PP
+Anthropic endpoints must use HTTPS. OpenAI-compatible endpoints may use plain HTTP on localhost, loopback IPs, and
 .B 192.168.x.x
 by default; other non-HTTPS hosts require
 .BR allow_insecure_http " = true" .

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,7 +50,9 @@ pub struct AuthCommand {
 #[derive(clap::Subcommand, Debug)]
 pub enum AuthAction {
     Add { provider: String },
+    Login { provider: String },
     List,
+    Logout { provider: String },
     Remove { provider: String },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use crate::paths::config_path;
 use crate::providers::anthropic::DEFAULT_ANTHROPIC_ENDPOINT;
 use crate::providers::ollama::DEFAULT_OLLAMA_ENDPOINT;
-use crate::providers::openai::DEFAULT_OPENAI_ENDPOINT;
 use crate::providers::openai_compatible::validate_compatible_endpoint;
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
@@ -29,9 +28,9 @@ pub enum ProviderConfig {
     #[serde(rename = "openai")]
     OpenAi {
         #[serde(default)]
-        endpoint: Option<String>,
-        #[serde(default)]
         model: Option<String>,
+        #[serde(default)]
+        endpoint: Option<String>,
     },
     Anthropic {
         #[serde(default)]
@@ -110,10 +109,14 @@ pub fn validate_config(config: &StoredConfig) -> Result<()> {
             validate_endpoint(endpoint)?;
         }
         ProviderConfig::OpenAi { endpoint, .. } => {
-            validate_https_endpoint(
-                endpoint.as_deref().unwrap_or(DEFAULT_OPENAI_ENDPOINT),
-                "OpenAI",
-            )?;
+            if endpoint
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            {
+                return Err(anyhow!(
+                    "OpenAI no longer accepts `endpoint`. Use `type = \"openai-compatible\"` with `endpoint = \"https://api.openai.com/v1\"` for API-key access."
+                ));
+            }
         }
         ProviderConfig::Anthropic { endpoint, .. } => {
             validate_https_endpoint(
@@ -196,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_non_https_openai_endpoint() {
+    fn rejects_openai_endpoint_migration_path() {
         let config: StoredConfig = toml::from_str(
             r#"
             active_provider = "openai"
@@ -209,7 +212,10 @@ mod tests {
         )
         .expect("parse config");
 
-        let err = validate_config(&config).expect_err("http openai should fail");
-        assert!(err.to_string().contains("OpenAI endpoints must use HTTPS"));
+        let err = validate_config(&config).expect_err("openai endpoint should fail");
+        assert!(
+            err.to_string()
+                .contains("OpenAI no longer accepts `endpoint`")
+        );
     }
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -9,7 +9,6 @@ const KEYRING_SERVICE: &str = "rosie";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CredentialTarget {
-    OpenAi,
     Anthropic,
     NamedProvider(String),
 }
@@ -17,7 +16,6 @@ pub enum CredentialTarget {
 impl fmt::Display for CredentialTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::OpenAi => write!(f, "openai"),
             Self::Anthropic => write!(f, "anthropic"),
             Self::NamedProvider(name) => write!(f, "{name}"),
         }
@@ -35,6 +33,31 @@ pub struct CredentialStatus {
     pub env_var: Option<String>,
     pub has_env: bool,
     pub has_keychain: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthKind {
+    Native,
+    ApiKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeAuthStatus {
+    pub cli_available: bool,
+    pub logged_in: bool,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProviderAuthStatus {
+    pub provider_name: String,
+    pub auth_kind: AuthKind,
+    pub env_var: Option<String>,
+    pub has_env: bool,
+    pub has_keychain: bool,
+    pub cli_available: bool,
+    pub logged_in: bool,
+    pub detail: Option<String>,
 }
 
 pub trait SecretStore: Send + Sync {
@@ -127,7 +150,7 @@ impl CredentialManager {
     }
 
     pub fn list_statuses(&self, config: Option<&StoredConfig>) -> Result<Vec<CredentialStatus>> {
-        let mut targets = vec![CredentialTarget::OpenAi, CredentialTarget::Anthropic];
+        let mut targets = vec![CredentialTarget::Anthropic];
         if let Some(config) = config {
             for (name, provider) in &config.providers {
                 if matches!(provider, ProviderConfig::OpenAiCompatible { .. }) {
@@ -158,6 +181,45 @@ impl CredentialManager {
 
         Ok(statuses)
     }
+
+    pub fn list_provider_auth_statuses<F>(
+        &self,
+        config: Option<&StoredConfig>,
+        native_status_for_provider: F,
+    ) -> Result<Vec<ProviderAuthStatus>>
+    where
+        F: Fn(&str) -> Option<NativeAuthStatus>,
+    {
+        let mut statuses = Vec::new();
+
+        if let Some(status) = native_status_for_provider("openai") {
+            statuses.push(ProviderAuthStatus {
+                provider_name: "openai".to_string(),
+                auth_kind: AuthKind::Native,
+                env_var: None,
+                has_env: false,
+                has_keychain: false,
+                cli_available: status.cli_available,
+                logged_in: status.logged_in,
+                detail: Some(status.detail),
+            });
+        }
+
+        for status in self.list_statuses(config)? {
+            statuses.push(ProviderAuthStatus {
+                provider_name: status.target.to_string(),
+                auth_kind: AuthKind::ApiKey,
+                env_var: status.env_var,
+                has_env: status.has_env,
+                has_keychain: status.has_keychain,
+                cli_available: false,
+                logged_in: false,
+                detail: None,
+            });
+        }
+
+        Ok(statuses)
+    }
 }
 
 pub fn credential_target_for_provider(
@@ -166,7 +228,7 @@ pub fn credential_target_for_provider(
 ) -> Result<Option<CredentialTarget>> {
     match provider {
         ProviderConfig::Ollama { .. } => Ok(None),
-        ProviderConfig::OpenAi { .. } => Ok(Some(CredentialTarget::OpenAi)),
+        ProviderConfig::OpenAi { .. } => Ok(None),
         ProviderConfig::Anthropic { .. } => Ok(Some(CredentialTarget::Anthropic)),
         ProviderConfig::OpenAiCompatible { .. } => Ok(Some(CredentialTarget::NamedProvider(
             provider_name.to_string(),
@@ -178,10 +240,13 @@ pub fn credential_target_from_name(
     config: Option<&StoredConfig>,
     provider_name: &str,
 ) -> Result<CredentialTarget> {
-    match provider_name {
-        "openai" => return Ok(CredentialTarget::OpenAi),
-        "anthropic" => return Ok(CredentialTarget::Anthropic),
-        _ => {}
+    if provider_name == "openai" {
+        return Err(anyhow!(
+            "Provider 'openai' uses native login. Run `rosie auth login openai`."
+        ));
+    }
+    if provider_name == "anthropic" {
+        return Ok(CredentialTarget::Anthropic);
     }
 
     let config = config.ok_or_else(|| {
@@ -197,7 +262,6 @@ pub fn credential_target_from_name(
 
 pub fn env_var_name(target: &CredentialTarget) -> Option<String> {
     match target {
-        CredentialTarget::OpenAi => Some("OPENAI_API_KEY".to_string()),
         CredentialTarget::Anthropic => Some("ANTHROPIC_API_KEY".to_string()),
         CredentialTarget::NamedProvider(name) => {
             Some(format!("ROSIE_{}_API_KEY", normalize_env_name(name)))
@@ -207,7 +271,6 @@ pub fn env_var_name(target: &CredentialTarget) -> Option<String> {
 
 fn account_name(target: &CredentialTarget) -> Cow<'_, str> {
     match target {
-        CredentialTarget::OpenAi => Cow::Borrowed("openai"),
         CredentialTarget::Anthropic => Cow::Borrowed("anthropic"),
         CredentialTarget::NamedProvider(name) => Cow::Owned(format!("provider:{name}")),
     }
@@ -228,7 +291,8 @@ fn normalize_env_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        CredentialManager, CredentialTarget, SecretStore, credential_target_from_name, env_var_name,
+        AuthKind, CredentialManager, CredentialTarget, NativeAuthStatus, ProviderAuthStatus,
+        SecretStore, credential_target_from_name, env_var_name,
     };
     use crate::config::{ProviderConfig, StoredConfig};
     use anyhow::Result;
@@ -286,11 +350,11 @@ mod tests {
     fn resolve_prefers_keychain_after_env_miss() {
         let manager = CredentialManager::with_store(Arc::new(MemoryStore::new()));
         manager
-            .set(&CredentialTarget::OpenAi, "test-secret")
+            .set(&CredentialTarget::Anthropic, "test-secret")
             .expect("set secret");
 
         let resolved = manager
-            .resolve(&CredentialTarget::OpenAi, None)
+            .resolve(&CredentialTarget::Anthropic, None)
             .expect("resolve")
             .expect("credential");
         assert_eq!(resolved.secret, "test-secret");
@@ -316,5 +380,59 @@ mod tests {
 
         let target = credential_target_from_name(Some(&config), "local").expect("target");
         assert_eq!(target, CredentialTarget::NamedProvider("local".to_string()));
+    }
+
+    #[test]
+    fn openai_requires_native_login() {
+        let err = credential_target_from_name(None, "openai").expect_err("openai should fail");
+        assert!(err.to_string().contains("Run `rosie auth login openai`"));
+    }
+
+    #[test]
+    fn list_provider_auth_statuses_includes_native_and_api_key_entries() {
+        let manager = CredentialManager::with_store(Arc::new(MemoryStore::new()));
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "local".to_string(),
+            ProviderConfig::OpenAiCompatible {
+                endpoint: "https://api.openai.com/v1".to_string(),
+                model: Some("gpt-5".to_string()),
+                allow_insecure_http: false,
+            },
+        );
+        let config = StoredConfig {
+            active_provider: Some("local".to_string()),
+            providers,
+            theme: None,
+            execution_enabled: Some(true),
+        };
+
+        let statuses = manager
+            .list_provider_auth_statuses(Some(&config), |provider_name| {
+                (provider_name == "openai").then(|| NativeAuthStatus {
+                    cli_available: true,
+                    logged_in: true,
+                    detail: "Logged in using ChatGPT".to_string(),
+                })
+            })
+            .expect("list statuses");
+
+        assert_eq!(
+            statuses[0],
+            ProviderAuthStatus {
+                provider_name: "openai".to_string(),
+                auth_kind: AuthKind::Native,
+                env_var: None,
+                has_env: false,
+                has_keychain: false,
+                cli_available: true,
+                logged_in: true,
+                detail: Some("Logged in using ChatGPT".to_string()),
+            }
+        );
+        assert_eq!(statuses[1].provider_name, "anthropic");
+        assert_eq!(statuses[1].auth_kind, AuthKind::ApiKey);
+        assert_eq!(statuses[2].provider_name, "local");
+        assert_eq!(statuses[2].env_var, Some("ROSIE_LOCAL_API_KEY".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,7 @@ mod tui;
 use anyhow::{Result, anyhow};
 use cli::{AuthAction, Command as CliCommand, parse_args};
 use config::{ProviderConfig, StoredConfig, load_config};
-use credentials::{
-    AuthKind, CredentialManager, credential_target_from_name, env_var_name,
-};
+use credentials::{AuthKind, CredentialManager, credential_target_from_name, env_var_name};
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use install::install;
@@ -335,8 +333,8 @@ fn handle_auth_command(action: AuthAction) -> Result<()> {
             run_openai_login()
         }
         AuthAction::List => {
-            let statuses =
-                manager.list_provider_auth_statuses(config.as_ref(), |provider_name| {
+            let statuses = manager
+                .list_provider_auth_statuses(config.as_ref(), |provider_name| {
                     (provider_name == "openai").then(openai_login_status)
                 })?;
             for status in statuses {
@@ -485,56 +483,6 @@ async fn configure_provider(
             })
         }
         _ => Err(anyhow!("Unsupported provider type '{}'", provider_kind)),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::handle_auth_command;
-    use crate::cli::AuthAction;
-
-    #[test]
-    fn auth_add_openai_is_deprecated() {
-        let err = handle_auth_command(AuthAction::Add {
-            provider: "openai".to_string(),
-        })
-        .expect_err("openai add should be rejected");
-        assert!(err
-            .to_string()
-            .contains("Run `rosie auth login openai`"));
-    }
-
-    #[test]
-    fn auth_remove_openai_is_deprecated() {
-        let err = handle_auth_command(AuthAction::Remove {
-            provider: "openai".to_string(),
-        })
-        .expect_err("openai remove should be rejected");
-        assert!(err
-            .to_string()
-            .contains("Run `rosie auth login openai`"));
-    }
-
-    #[test]
-    fn auth_login_only_supports_openai() {
-        let err = handle_auth_command(AuthAction::Login {
-            provider: "anthropic".to_string(),
-        })
-        .expect_err("native login should be limited to openai");
-        assert!(err
-            .to_string()
-            .contains("currently only supported for 'openai'"));
-    }
-
-    #[test]
-    fn auth_logout_only_supports_openai() {
-        let err = handle_auth_command(AuthAction::Logout {
-            provider: "anthropic".to_string(),
-        })
-        .expect_err("native logout should be limited to openai");
-        assert!(err
-            .to_string()
-            .contains("currently only supported for 'openai'"));
     }
 }
 
@@ -754,5 +702,53 @@ fn prompt_continue_or_exit(reason: &str) -> Result<bool> {
         }
 
         println!("Please enter 'c' to continue or 'e' to exit.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::handle_auth_command;
+    use crate::cli::AuthAction;
+
+    #[test]
+    fn auth_add_openai_is_deprecated() {
+        let err = handle_auth_command(AuthAction::Add {
+            provider: "openai".to_string(),
+        })
+        .expect_err("openai add should be rejected");
+        assert!(err.to_string().contains("Run `rosie auth login openai`"));
+    }
+
+    #[test]
+    fn auth_remove_openai_is_deprecated() {
+        let err = handle_auth_command(AuthAction::Remove {
+            provider: "openai".to_string(),
+        })
+        .expect_err("openai remove should be rejected");
+        assert!(err.to_string().contains("Run `rosie auth login openai`"));
+    }
+
+    #[test]
+    fn auth_login_only_supports_openai() {
+        let err = handle_auth_command(AuthAction::Login {
+            provider: "anthropic".to_string(),
+        })
+        .expect_err("native login should be limited to openai");
+        assert!(
+            err.to_string()
+                .contains("currently only supported for 'openai'")
+        );
+    }
+
+    #[test]
+    fn auth_logout_only_supports_openai() {
+        let err = handle_auth_command(AuthAction::Logout {
+            provider: "anthropic".to_string(),
+        })
+        .expect_err("native logout should be limited to openai");
+        assert!(
+            err.to_string()
+                .contains("currently only supported for 'openai'")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,13 +13,18 @@ mod tui;
 use anyhow::{Result, anyhow};
 use cli::{AuthAction, Command as CliCommand, parse_args};
 use config::{ProviderConfig, StoredConfig, load_config};
-use credentials::{CredentialManager, credential_target_from_name, env_var_name};
+use credentials::{
+    AuthKind, CredentialManager, credential_target_from_name, env_var_name,
+};
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use install::install;
 use llm::{GeneratedCommand, generate_chat_with_spinner, generate_command_with_spinner};
 use paths::{app_data_dir, config_path};
 use providers::ollama::{DEFAULT_OLLAMA_ENDPOINT, discover_ollama_models};
+use providers::openai::{
+    native_openai_model_presets, openai_login_status, run_openai_login, run_openai_logout,
+};
 use std::env;
 use std::fs;
 use std::io;
@@ -321,23 +326,65 @@ fn handle_auth_command(action: AuthAction) -> Result<()> {
             }
             Ok(())
         }
+        AuthAction::Login { provider } => {
+            if provider != "openai" {
+                return Err(anyhow!(
+                    "Native login is currently only supported for 'openai'."
+                ));
+            }
+            run_openai_login()
+        }
         AuthAction::List => {
-            let statuses = manager.list_statuses(config.as_ref())?;
+            let statuses =
+                manager.list_provider_auth_statuses(config.as_ref(), |provider_name| {
+                    (provider_name == "openai").then(openai_login_status)
+                })?;
             for status in statuses {
-                let env_label = status.env_var.unwrap_or_else(|| "-".to_string());
-                println!(
-                    "{}: env={} ({}) keychain={}",
-                    status.target,
-                    env_label,
-                    if status.has_env { "set" } else { "unset" },
-                    if status.has_keychain {
-                        "stored"
-                    } else {
-                        "empty"
+                match status.auth_kind {
+                    AuthKind::Native => {
+                        println!(
+                            "{}: native cli={} login={}",
+                            status.provider_name,
+                            if status.cli_available {
+                                "available"
+                            } else {
+                                "missing"
+                            },
+                            if status.logged_in {
+                                "logged-in"
+                            } else {
+                                "logged-out"
+                            }
+                        );
                     }
-                );
+                    AuthKind::ApiKey => {
+                        let env_label = status.env_var.unwrap_or_else(|| "-".to_string());
+                        println!(
+                            "{}: env={} ({}) keychain={}",
+                            status.provider_name,
+                            env_label,
+                            if status.has_env { "set" } else { "unset" },
+                            if status.has_keychain {
+                                "stored"
+                            } else {
+                                "empty"
+                            }
+                        );
+                    }
+                }
+                if let Some(detail) = status.detail.filter(|value| !value.trim().is_empty()) {
+                    println!("  {}", detail.trim());
+                }
             }
             Ok(())
+        }
+        AuthAction::Logout { provider } => {
+            if provider != "openai" {
+                return Err(anyhow!(
+                    "Native logout is currently only supported for 'openai'."
+                ));
+            }
+            run_openai_logout()
         }
         AuthAction::Remove { provider } => {
             let target = credential_target_from_name(config.as_ref(), &provider)?;
@@ -378,20 +425,20 @@ async fn configure_provider(
     match provider_kind.as_str() {
         "ollama" => configure_ollama_provider(existing_provider).await,
         "openai" => {
-            let (current_endpoint, current_model) = match existing_provider {
-                ProviderConfig::OpenAi { endpoint, model } => {
-                    (endpoint.as_deref(), model.as_deref())
-                }
-                _ => (None, None),
+            let current_model = match existing_provider {
+                ProviderConfig::OpenAi { model, .. } => model.as_deref(),
+                _ => None,
             };
-            let endpoint = prompt_config_value(
-                "OpenAI endpoint (optional, defaults to official API)",
-                current_endpoint,
-                true,
-            )?;
+            let models = native_openai_model_presets();
             Ok(ProviderConfig::OpenAi {
-                endpoint: normalize_config_value(endpoint),
-                model: normalize_config_value(prompt_config_value("Model", current_model, false)?),
+                model: normalize_config_value(prompt_model_with_confirmation(
+                    "Model",
+                    current_model,
+                    false,
+                    &models,
+                    None,
+                )?),
+                endpoint: None,
             })
         }
         "anthropic" => {
@@ -438,6 +485,56 @@ async fn configure_provider(
             })
         }
         _ => Err(anyhow!("Unsupported provider type '{}'", provider_kind)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::handle_auth_command;
+    use crate::cli::AuthAction;
+
+    #[test]
+    fn auth_add_openai_is_deprecated() {
+        let err = handle_auth_command(AuthAction::Add {
+            provider: "openai".to_string(),
+        })
+        .expect_err("openai add should be rejected");
+        assert!(err
+            .to_string()
+            .contains("Run `rosie auth login openai`"));
+    }
+
+    #[test]
+    fn auth_remove_openai_is_deprecated() {
+        let err = handle_auth_command(AuthAction::Remove {
+            provider: "openai".to_string(),
+        })
+        .expect_err("openai remove should be rejected");
+        assert!(err
+            .to_string()
+            .contains("Run `rosie auth login openai`"));
+    }
+
+    #[test]
+    fn auth_login_only_supports_openai() {
+        let err = handle_auth_command(AuthAction::Login {
+            provider: "anthropic".to_string(),
+        })
+        .expect_err("native login should be limited to openai");
+        assert!(err
+            .to_string()
+            .contains("currently only supported for 'openai'"));
+    }
+
+    #[test]
+    fn auth_logout_only_supports_openai() {
+        let err = handle_auth_command(AuthAction::Logout {
+            provider: "anthropic".to_string(),
+        })
+        .expect_err("native logout should be limited to openai");
+        assert!(err
+            .to_string()
+            .contains("currently only supported for 'openai'"));
     }
 }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -103,11 +103,9 @@ impl ProviderRouter {
             ProviderConfig::Ollama { endpoint, model } => {
                 Arc::new(OllamaProvider::new(endpoint.clone(), model.clone()))
             }
-            ProviderConfig::OpenAi { endpoint, model } => Arc::new(OpenAiProvider::new(
-                endpoint.clone(),
-                model.clone(),
-                credentials.clone(),
-            )),
+            ProviderConfig::OpenAi { model, .. } => {
+                Arc::new(OpenAiProvider::new(model.clone(), credentials.clone()))
+            }
             ProviderConfig::Anthropic { endpoint, model } => Arc::new(AnthropicProvider::new(
                 endpoint.clone(),
                 model.clone(),

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -1,86 +1,44 @@
-use crate::credentials::{CredentialManager, CredentialTarget};
+use crate::credentials::{CredentialManager, NativeAuthStatus};
 use crate::provider::{ChatRequest, ChatResponse, Message, Provider, ProviderEvent, Role};
 use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::env;
 use std::future::Future;
 use std::pin::Pin;
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command as TokioCommand;
 use tokio::sync::mpsc;
 
-pub const DEFAULT_OPENAI_ENDPOINT: &str = "https://api.openai.com/v1";
+const DEFAULT_OPENAI_CLI: &str = "codex";
+const OPENAI_CLI_ENV_VAR: &str = "ROSIE_OPENAI_CLI";
+pub const NATIVE_OPENAI_MODEL_PRESETS: &[&str] = &["gpt-5-codex", "gpt-5"];
 
 pub struct OpenAiProvider {
-    endpoint: String,
     model: Option<String>,
+    #[allow(dead_code)]
     credentials: CredentialManager,
+    cli_path: String,
 }
 
 impl OpenAiProvider {
-    pub fn new(
-        endpoint: Option<String>,
-        model: Option<String>,
-        credentials: CredentialManager,
-    ) -> Self {
+    pub fn new(model: Option<String>, credentials: CredentialManager) -> Self {
         Self {
-            endpoint: endpoint.unwrap_or_else(|| DEFAULT_OPENAI_ENDPOINT.to_string()),
             model,
             credentials,
+            cli_path: openai_cli_path(),
         }
     }
-}
 
-#[derive(Serialize)]
-struct OpenAiChatRequest {
-    model: String,
-    messages: Vec<OpenAiMessage>,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    stream: bool,
-}
-
-#[derive(Serialize)]
-struct OpenAiMessage {
-    role: String,
-    content: String,
-}
-
-#[derive(Deserialize)]
-struct OpenAiChoice {
-    message: OpenAiResponseMessage,
-}
-
-#[derive(Deserialize)]
-struct OpenAiResponseMessage {
-    role: String,
-    content: String,
-}
-
-#[derive(Deserialize)]
-struct OpenAiStreamChoice {
-    delta: OpenAiStreamDelta,
-}
-
-#[derive(Deserialize)]
-struct OpenAiStreamDelta {
-    content: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct OpenAiStreamResponse {
-    choices: Vec<OpenAiStreamChoice>,
-}
-
-#[derive(Deserialize)]
-struct OpenAiChatResponse {
-    choices: Vec<OpenAiChoice>,
-}
-
-#[derive(Deserialize)]
-struct OpenAiModelItem {
-    id: String,
-}
-
-#[derive(Deserialize)]
-struct OpenAiModelsResponse {
-    data: Vec<OpenAiModelItem>,
+    #[cfg(test)]
+    pub fn with_cli_path(model: Option<String>, cli_path: String) -> Self {
+        Self {
+            model,
+            credentials: CredentialManager::new(),
+            cli_path,
+        }
+    }
 }
 
 impl Provider for OpenAiProvider {
@@ -92,108 +50,22 @@ impl Provider for OpenAiProvider {
         self.model.as_deref()
     }
 
-    fn supports_model_discovery(&self) -> bool {
-        true
-    }
-
     fn chat(
         &self,
         request: ChatRequest,
     ) -> Pin<Box<dyn Future<Output = Result<ChatResponse>> + Send + '_>> {
         Box::pin(async move {
-            let api_key = self
-                .credentials
-                .resolve(&CredentialTarget::OpenAi, None)?
-                .ok_or_else(|| {
-                    anyhow!(
-                        "Missing OpenAI API key. Set OPENAI_API_KEY or run `rosie auth add openai`."
-                    )
-                })?
-                .secret;
-
-            let request_body = OpenAiChatRequest {
-                model: request.model,
-                messages: request
-                    .messages
-                    .into_iter()
-                    .map(|message| OpenAiMessage {
-                        role: message.role.as_str().to_string(),
-                        content: message.content,
-                    })
-                    .collect(),
-                stream: false,
-            };
-
-            let resp = reqwest::Client::new()
-                .post(format!(
-                    "{}/chat/completions",
-                    self.endpoint.trim_end_matches('/')
-                ))
-                .bearer_auth(api_key)
-                .json(&request_body)
-                .send()
-                .await
-                .map_err(|e| anyhow!("HTTP send error: {e}"))?;
-
-            if !resp.status().is_success() {
-                return Err(anyhow!(
-                    "API returned {}: {}",
-                    resp.status(),
-                    resp.text().await?
-                ));
+            let result = run_openai_exec(&self.cli_path, request, None).await?;
+            if result.text.trim().is_empty() {
+                return Err(anyhow!("OpenAI CLI returned no assistant content"));
             }
 
-            let completion: OpenAiChatResponse = resp
-                .json()
-                .await
-                .map_err(|e| anyhow!("JSON parse error: {e}"))?;
-
-            completion
-                .choices
-                .into_iter()
-                .next()
-                .map(|choice| ChatResponse {
-                    message: Message {
-                        role: role_from_str(&choice.message.role),
-                        content: choice.message.content.trim().to_string(),
-                    },
-                })
-                .ok_or_else(|| anyhow!("No choices returned"))
-        })
-    }
-
-    fn list_models(&self) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + '_>> {
-        Box::pin(async move {
-            let api_key = self
-                .credentials
-                .resolve(&CredentialTarget::OpenAi, None)?
-                .ok_or_else(|| {
-                    anyhow!(
-                        "Missing OpenAI API key. Set OPENAI_API_KEY or run `rosie auth add openai`."
-                    )
-                })?
-                .secret;
-
-            let resp = reqwest::Client::new()
-                .get(format!("{}/models", self.endpoint.trim_end_matches('/')))
-                .bearer_auth(api_key)
-                .send()
-                .await
-                .map_err(|e| anyhow!("HTTP send error for model discovery: {e}"))?;
-
-            if !resp.status().is_success() {
-                return Err(anyhow!(
-                    "Model discovery returned {}: {}",
-                    resp.status(),
-                    resp.text().await?
-                ));
-            }
-
-            let response: OpenAiModelsResponse = resp
-                .json()
-                .await
-                .map_err(|e| anyhow!("Failed to parse model discovery JSON: {e}"))?;
-            Ok(response.data.into_iter().map(|item| item.id).collect())
+            Ok(ChatResponse {
+                message: Message {
+                    role: Role::Assistant,
+                    content: result.text.trim().to_string(),
+                },
+            })
         })
     }
 
@@ -203,244 +75,667 @@ impl Provider for OpenAiProvider {
         tx: mpsc::UnboundedSender<ProviderEvent>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
         Box::pin(async move {
-            let api_key = self
-                .credentials
-                .resolve(&CredentialTarget::OpenAi, None)?
-                .ok_or_else(|| {
-                    anyhow!(
-                        "Missing OpenAI API key. Set OPENAI_API_KEY or run `rosie auth add openai`."
-                    )
-                })?
-                .secret;
-
-            let request_body = OpenAiChatRequest {
-                model: request.model,
-                messages: request
-                    .messages
-                    .into_iter()
-                    .map(|message| OpenAiMessage {
-                        role: message.role.as_str().to_string(),
-                        content: message.content,
-                    })
-                    .collect(),
-                stream: true,
-            };
-
-            let mut resp = reqwest::Client::new()
-                .post(format!(
-                    "{}/chat/completions",
-                    self.endpoint.trim_end_matches('/')
-                ))
-                .bearer_auth(api_key)
-                .json(&request_body)
-                .send()
-                .await
-                .map_err(|e| anyhow!("HTTP send error: {e}"))?;
-
-            if !resp.status().is_success() {
-                return Err(anyhow!(
-                    "API returned {}: {}",
-                    resp.status(),
-                    resp.text().await?
-                ));
+            let result = run_openai_exec(&self.cli_path, request, Some(tx.clone())).await?;
+            if !result.text.trim().is_empty() && !result.emitted_any_tokens {
+                let _ = tx.send(ProviderEvent::Token(result.text.trim().to_string()));
             }
-
-            let mut buffer = String::new();
-            while let Some(chunk) = resp
-                .chunk()
-                .await
-                .map_err(|e| anyhow!("Stream read error: {e}"))?
-            {
-                buffer.push_str(&String::from_utf8_lossy(&chunk));
-                while let Some(newline_pos) = buffer.find('\n') {
-                    let line = buffer[..newline_pos].trim().to_string();
-                    buffer = buffer[newline_pos + 1..].to_string();
-                    if line.is_empty() {
-                        continue;
-                    }
-                    parse_openai_stream_line(&line, &tx)?;
-                }
-            }
-
-            if !buffer.trim().is_empty() {
-                parse_openai_stream_line(buffer.trim(), &tx)?;
-            }
-
             let _ = tx.send(ProviderEvent::Done);
             Ok(())
         })
     }
 }
 
-fn role_from_str(value: &str) -> Role {
-    match value {
-        "system" => Role::System,
-        "assistant" => Role::Assistant,
-        "tool" => Role::Tool,
-        _ => Role::User,
-    }
+pub fn openai_login_status() -> NativeAuthStatus {
+    openai_login_status_for_path(&openai_cli_path())
 }
 
-fn parse_openai_stream_line(line: &str, tx: &mpsc::UnboundedSender<ProviderEvent>) -> Result<()> {
-    let Some(payload) = sse_payload(line) else {
-        return Ok(());
-    };
-    if payload == "[DONE]" {
-        return Ok(());
-    }
+pub fn native_openai_model_presets() -> Vec<String> {
+    NATIVE_OPENAI_MODEL_PRESETS
+        .iter()
+        .map(|model| (*model).to_string())
+        .collect()
+}
 
-    let parsed: OpenAiStreamResponse =
-        serde_json::from_str(payload).map_err(|e| anyhow!("Failed to parse stream JSON: {e}"))?;
-    for choice in parsed.choices {
-        if let Some(content) = choice.delta.content
-            && !content.is_empty()
-        {
-            let _ = tx.send(ProviderEvent::Token(content));
+fn openai_login_status_for_path(cli_path: &str) -> NativeAuthStatus {
+    let output = Command::new(&cli_path)
+        .args(["login", "status"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output();
+
+    match output {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let detail = if !stdout.is_empty() { stdout } else { stderr };
+            NativeAuthStatus {
+                cli_available: true,
+                logged_in: output.status.success() && detail.contains("Logged in"),
+                detail,
+            }
         }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => NativeAuthStatus {
+            cli_available: false,
+            logged_in: false,
+            detail: format!(
+                "Install the OpenAI Codex CLI or set {} to its executable path.",
+                OPENAI_CLI_ENV_VAR
+            ),
+        },
+        Err(err) => NativeAuthStatus {
+            cli_available: false,
+            logged_in: false,
+            detail: format!("Failed to run OpenAI CLI: {err}"),
+        },
     }
-    Ok(())
 }
 
-fn sse_payload(line: &str) -> Option<&str> {
-    let trimmed = line.trim();
-    if trimmed.is_empty() || trimmed.starts_with(':') || trimmed.starts_with("event:") {
-        return None;
+pub fn run_openai_login() -> Result<()> {
+    let cli_path = openai_cli_path();
+    let status = Command::new(&cli_path)
+        .arg("login")
+        .status()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                anyhow!(
+                    "OpenAI CLI not found. Install Codex or set {} to its executable path.",
+                    OPENAI_CLI_ENV_VAR
+                )
+            } else {
+                anyhow!("Failed to launch OpenAI login: {err}")
+            }
+        })?;
+
+    if status.success() {
+        println!("OpenAI login completed.");
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "OpenAI login failed with status {}",
+            status.code().unwrap_or(1)
+        ))
+    }
+}
+
+pub fn run_openai_logout() -> Result<()> {
+    let cli_path = openai_cli_path();
+    let status = Command::new(&cli_path)
+        .arg("logout")
+        .status()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                anyhow!(
+                    "OpenAI CLI not found. Install Codex or set {} to its executable path.",
+                    OPENAI_CLI_ENV_VAR
+                )
+            } else {
+                anyhow!("Failed to launch OpenAI logout: {err}")
+            }
+        })?;
+
+    if status.success() {
+        println!("OpenAI login removed.");
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "OpenAI logout failed with status {}",
+            status.code().unwrap_or(1)
+        ))
+    }
+}
+
+fn openai_cli_path() -> String {
+    env::var(OPENAI_CLI_ENV_VAR).unwrap_or_else(|_| DEFAULT_OPENAI_CLI.to_string())
+}
+
+struct OpenAiExecResult {
+    text: String,
+    emitted_any_tokens: bool,
+}
+
+async fn run_openai_exec(
+    cli_path: &str,
+    request: ChatRequest,
+    tx: Option<mpsc::UnboundedSender<ProviderEvent>>,
+) -> Result<OpenAiExecResult> {
+    let status = openai_login_status_for_path(cli_path);
+    if !status.cli_available {
+        return Err(anyhow!(status.detail));
+    }
+    if !status.logged_in {
+        return Err(anyhow!(
+            "OpenAI is not logged in. Run `rosie auth login openai`."
+        ));
     }
 
-    let payload = trimmed.strip_prefix("data:").unwrap_or(trimmed).trim();
-    (!payload.is_empty()).then_some(payload)
+    let prompt = render_prompt(&request.messages);
+    let cwd =
+        env::current_dir().map_err(|err| anyhow!("Failed to read current directory: {err}"))?;
+
+    let mut command = TokioCommand::new(cli_path);
+    command
+        .kill_on_drop(true)
+        .arg("exec")
+        .arg("--json")
+        .arg("--skip-git-repo-check")
+        .arg("--sandbox")
+        .arg("read-only")
+        .arg("--color")
+        .arg("never")
+        .arg("--cd")
+        .arg(&cwd)
+        .arg("-");
+
+    if !request.model.trim().is_empty() {
+        command.arg("--model").arg(&request.model);
+    }
+
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let mut child = command.spawn().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            anyhow!(
+                "OpenAI CLI not found. Install Codex or set {} to its executable path.",
+                OPENAI_CLI_ENV_VAR
+            )
+        } else {
+            anyhow!("Failed to launch OpenAI CLI: {err}")
+        }
+    })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let prompt_copy = prompt.clone();
+        tokio::spawn(async move {
+            let _ = stdin.write_all(prompt_copy.as_bytes()).await;
+            let _ = stdin.shutdown().await;
+        });
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("OpenAI CLI stdout was unavailable"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("OpenAI CLI stderr was unavailable"))?;
+
+    let state = Arc::new(tokio::sync::Mutex::new(StreamState::default()));
+    let stdout_state = Arc::clone(&state);
+    let stdout_tx = tx.clone();
+    let stdout_task = tokio::spawn(async move {
+        let mut reader = BufReader::new(stdout).lines();
+        while let Some(line) = reader.next_line().await? {
+            parse_exec_event_line(&line, stdout_tx.as_ref(), &stdout_state).await;
+        }
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let stderr_task = tokio::spawn(async move {
+        let mut buffer = String::new();
+        let mut reader = BufReader::new(stderr);
+        reader.read_to_string(&mut buffer).await?;
+        Ok::<String, anyhow::Error>(buffer)
+    });
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|err| anyhow!("OpenAI CLI failed: {err}"))?;
+    stdout_task
+        .await
+        .map_err(|err| anyhow!("OpenAI CLI stdout task failed: {err}"))??;
+    let stderr_output = stderr_task
+        .await
+        .map_err(|err| anyhow!("OpenAI CLI stderr task failed: {err}"))??;
+
+    let (streamed_text, emitted_any_tokens) = {
+        let state = state.lock().await;
+        (state.text.clone(), state.emitted_any_tokens)
+    };
+    let final_text = streamed_text;
+
+    if status.success() {
+        return Ok(OpenAiExecResult {
+            text: final_text,
+            emitted_any_tokens,
+        });
+    }
+
+    let stderr_output = stderr_output.trim();
+    if stderr_output.contains("Not logged in") || stderr_output.contains("login") {
+        return Err(anyhow!(
+            "OpenAI is not logged in. Run `rosie auth login openai`."
+        ));
+    }
+
+    if !stderr_output.is_empty() {
+        return Err(anyhow!(
+            "OpenAI CLI failed with status {}: {}",
+            status.code().unwrap_or(1),
+            stderr_output
+        ));
+    }
+
+    Err(anyhow!(
+        "OpenAI CLI failed with status {}",
+        status.code().unwrap_or(1)
+    ))
+}
+
+#[derive(Default)]
+struct StreamState {
+    text: String,
+    emitted_any_tokens: bool,
+}
+
+async fn parse_exec_event_line(
+    line: &str,
+    tx: Option<&mpsc::UnboundedSender<ProviderEvent>>,
+    state: &Arc<tokio::sync::Mutex<StreamState>>,
+) {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        return;
+    };
+
+    let fragments = extract_text_fragments(&value);
+    if fragments.is_empty() {
+        return;
+    }
+
+    let mut state = state.lock().await;
+    for fragment in fragments {
+        if fragment.trim().is_empty() {
+            continue;
+        }
+
+        let delta = if fragment.starts_with(&state.text) {
+            fragment[state.text.len()..].to_string()
+        } else {
+            fragment.clone()
+        };
+
+        if delta.is_empty() {
+            continue;
+        }
+
+        state.text.push_str(&delta);
+        if let Some(tx) = tx {
+            let _ = tx.send(ProviderEvent::Token(delta));
+        }
+        state.emitted_any_tokens = true;
+    }
+}
+
+fn extract_text_fragments(value: &Value) -> Vec<String> {
+    let event_type = value
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    match event_type {
+        "response.output_text.delta" => value
+            .get("delta")
+            .and_then(Value::as_str)
+            .map(|text| vec![text.to_string()])
+            .unwrap_or_default(),
+        "item.completed" => extract_completed_item_text(value.get("item")),
+        _ => Vec::new(),
+    }
+}
+
+fn extract_completed_item_text(item: Option<&Value>) -> Vec<String> {
+    let Some(item) = item else {
+        return Vec::new();
+    };
+    if matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("agent_message" | "assistant_message")
+    ) && let Some(text) = item.get("text").and_then(Value::as_str)
+    {
+        return vec![text.to_string()];
+    }
+
+    let Some(content) = item.get("content").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    content
+        .iter()
+        .filter(|entry| {
+            matches!(
+                entry.get("type").and_then(Value::as_str),
+                Some("output_text" | "text")
+            )
+        })
+        .filter_map(|entry| entry.get("text").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+fn render_prompt(messages: &[Message]) -> String {
+    let mut prompt = String::from(
+        "You are acting as the chat backend for Rosie.\n\
+         Reply to the conversation directly.\n\
+         Do not inspect files, run shell commands, modify code, or use tools.\n\
+         Do not describe plans or actions unless the user explicitly asked for them.\n\n\
+         Conversation:\n",
+    );
+
+    for message in messages {
+        prompt.push_str(message.role.as_str());
+        prompt.push_str(":\n");
+        prompt.push_str(message.content.trim());
+        prompt.push_str("\n\n");
+    }
+
+    prompt.push_str("assistant:\n");
+    prompt
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{OpenAiProvider, parse_openai_stream_line};
-    use crate::credentials::{CredentialManager, CredentialTarget, SecretStore};
+    use super::{
+        NativeAuthStatus, OpenAiProvider, extract_completed_item_text, extract_text_fragments,
+        openai_login_status_for_path,
+    };
     use crate::provider::{ChatRequest, Message, Provider, ProviderEvent, Role};
-    use anyhow::Result;
-    use std::collections::BTreeMap;
-    use std::sync::{Arc, Mutex};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
+    use serde_json::json;
+    use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tokio::sync::mpsc;
+    use tokio::time::{sleep, timeout};
 
-    struct MemoryStore {
-        secrets: Mutex<BTreeMap<String, String>>,
-    }
+    #[test]
+    fn extracts_jsonl_delta_text() {
+        let value = json!({
+            "type": "response.output_text.delta",
+            "delta": "hello"
+        });
 
-    impl MemoryStore {
-        fn new() -> Self {
-            Self {
-                secrets: Mutex::new(BTreeMap::new()),
-            }
-        }
-    }
-
-    impl SecretStore for MemoryStore {
-        fn get_secret(&self, target: &CredentialTarget) -> Result<Option<String>> {
-            Ok(self
-                .secrets
-                .lock()
-                .expect("lock")
-                .get(&target.to_string())
-                .cloned())
-        }
-
-        fn set_secret(&self, target: &CredentialTarget, secret: &str) -> Result<()> {
-            self.secrets
-                .lock()
-                .expect("lock")
-                .insert(target.to_string(), secret.to_string());
-            Ok(())
-        }
-
-        fn delete_secret(&self, target: &CredentialTarget) -> Result<()> {
-            self.secrets
-                .lock()
-                .expect("lock")
-                .remove(&target.to_string());
-            Ok(())
-        }
+        assert_eq!(extract_text_fragments(&value), vec!["hello".to_string()]);
     }
 
     #[test]
-    fn parser_ignores_non_data_sse_lines() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        parse_openai_stream_line(": keep-alive", &tx).expect("comment ignored");
-        parse_openai_stream_line("event: message", &tx).expect("event ignored");
-        parse_openai_stream_line("data:", &tx).expect("empty data ignored");
-        assert!(rx.try_recv().is_err());
-    }
-
-    #[tokio::test]
-    async fn provider_streams_openai_sse_response() {
-        let listener = match TcpListener::bind("127.0.0.1:0").await {
-            Ok(listener) => listener,
-            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return,
-            Err(err) => panic!("bind: {err}"),
-        };
-        let addr = listener.local_addr().expect("addr");
-
-        let server = tokio::spawn(async move {
-            let (mut stream, _) = listener.accept().await.expect("accept");
-            let mut buffer = [0_u8; 4096];
-            let _ = stream.read(&mut buffer).await.expect("read");
-            let body = concat!(
-                "data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
-                "event: message\n",
-                "data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n",
-                "data: [DONE]\n\n"
-            );
-            let response = format!(
-                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            stream
-                .write_all(response.as_bytes())
-                .await
-                .expect("write response");
+    fn collects_nested_completed_text() {
+        let value = json!({
+            "type": "item.completed",
+            "item": {
+                "type": "assistant_message",
+                "content": [
+                    {"type": "output_text", "text": "hi"},
+                    {"type": "output_text", "text": " there"}
+                ]
+            }
         });
 
-        let store = Arc::new(MemoryStore::new());
-        store
-            .set_secret(&CredentialTarget::OpenAi, "test-key")
-            .expect("set secret");
-        let provider = OpenAiProvider::new(
-            Some(format!("http://{addr}/v1")),
-            Some("gpt-test".to_string()),
-            CredentialManager::with_store(store),
+        assert_eq!(
+            extract_completed_item_text(value.get("item")),
+            vec!["hi".to_string(), " there".to_string()]
         );
-        let (tx, mut rx) = mpsc::unbounded_channel();
+    }
 
+    #[test]
+    fn collects_agent_message_text() {
+        let value = json!({
+            "type": "item.completed",
+            "item": {
+                "type": "agent_message",
+                "text": "hi"
+            }
+        });
+
+        assert_eq!(extract_text_fragments(&value), vec!["hi".to_string()]);
+    }
+
+    #[test]
+    fn ignores_unrecognized_event_types() {
+        let value = json!({
+            "type": "response.completed",
+            "text": "should not be emitted"
+        });
+
+        assert!(extract_text_fragments(&value).is_empty());
+    }
+
+    #[test]
+    fn ignores_non_output_text_completed_items() {
+        let value = json!({
+            "type": "item.completed",
+            "item": {
+                "content": [
+                    {"type": "tool_call", "text": "skip"},
+                    {"type": "reasoning", "text": "skip"}
+                ]
+            }
+        });
+
+        assert!(extract_text_fragments(&value).is_empty());
+    }
+
+    #[cfg(unix)]
+    fn write_fake_cli(script_body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = env::temp_dir().join(format!("rosie-fake-codex-{}-{nanos}", std::process::id()));
+        fs::write(&path, script_body).expect("write script");
+        let mut perms = fs::metadata(&path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("chmod");
+        path
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provider_reads_completed_agent_message() {
+        let script = write_fake_cli(
+            r#"#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+if [ "$1" = "exec" ]; then
+  echo '{"type":"item.completed","item":{"type":"agent_message","text":"native reply"}}'
+  exit 0
+fi
+exit 1
+"#,
+        );
+
+        let provider = OpenAiProvider::with_cli_path(None, script.to_string_lossy().to_string());
+        let response = provider
+            .chat(ChatRequest {
+                model: "gpt-5".to_string(),
+                messages: vec![Message {
+                    role: Role::User,
+                    content: "hi".to_string(),
+                }],
+                temperature: None,
+            })
+            .await
+            .expect("chat response");
+
+        assert_eq!(response.message.content, "native reply");
+        let _ = fs::remove_file(script);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provider_streams_jsonl_deltas() {
+        let script = write_fake_cli(
+            r#"#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+if [ "$1" = "exec" ]; then
+  echo '{"type":"response.output_text.delta","delta":"Hel"}'
+  echo '{"type":"response.output_text.delta","delta":"lo"}'
+  exit 0
+fi
+exit 1
+"#,
+        );
+
+        let provider = OpenAiProvider::with_cli_path(None, script.to_string_lossy().to_string());
+        let (tx, mut rx) = mpsc::unbounded_channel();
         provider
             .stream_chat(
                 ChatRequest {
-                    model: "gpt-test".to_string(),
+                    model: "gpt-5".to_string(),
                     messages: vec![Message {
                         role: Role::User,
-                        content: "hello".to_string(),
+                        content: "hi".to_string(),
                     }],
                     temperature: None,
                 },
                 tx,
             )
             .await
-            .expect("stream chat");
-
-        let mut chunks = Vec::new();
-        while let Ok(event) = rx.try_recv() {
-            chunks.push(event);
-        }
+            .expect("stream response");
 
         assert_eq!(
-            chunks,
-            vec![
-                ProviderEvent::Token("Hel".to_string()),
-                ProviderEvent::Token("lo".to_string()),
-                ProviderEvent::Done,
-            ]
+            rx.recv().await,
+            Some(ProviderEvent::Token("Hel".to_string()))
+        );
+        assert_eq!(
+            rx.recv().await,
+            Some(ProviderEvent::Token("lo".to_string()))
+        );
+        assert_eq!(rx.recv().await, Some(ProviderEvent::Done));
+        let _ = fs::remove_file(script);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provider_errors_when_not_logged_in() {
+        let script = write_fake_cli(
+            r#"#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Not logged in"
+  exit 1
+fi
+exit 1
+"#,
         );
 
-        server.await.expect("server task");
+        let provider = OpenAiProvider::with_cli_path(None, script.to_string_lossy().to_string());
+        let err = provider
+            .chat(ChatRequest {
+                model: "gpt-5".to_string(),
+                messages: vec![Message {
+                    role: Role::User,
+                    content: "hi".to_string(),
+                }],
+                temperature: None,
+            })
+            .await
+            .expect_err("logged out provider should fail");
+
+        assert!(err
+            .to_string()
+            .contains("Run `rosie auth login openai`"));
+        let _ = fs::remove_file(script);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn aborting_stream_chat_kills_child_process() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let pid_file = env::temp_dir().join(format!("rosie-openai-pid-{}-{nanos}", std::process::id()));
+        let script = write_fake_cli(&format!(
+            r#"#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+if [ "$1" = "exec" ]; then
+  echo $$ > "{pid_file}"
+  while true; do
+    sleep 1
+  done
+fi
+exit 1
+"#,
+            pid_file = pid_file.display()
+        ));
+
+        let provider = OpenAiProvider::with_cli_path(None, script.to_string_lossy().to_string());
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let task = tokio::spawn(async move {
+            let _ = provider
+                .stream_chat(
+                    ChatRequest {
+                        model: "gpt-5".to_string(),
+                        messages: vec![Message {
+                            role: Role::User,
+                            content: "hi".to_string(),
+                        }],
+                        temperature: None,
+                    },
+                    tx,
+                )
+                .await;
+        });
+
+        let pid = timeout(Duration::from_secs(5), async {
+            loop {
+                if let Ok(contents) = fs::read_to_string(&pid_file)
+                    && let Ok(pid) = contents.trim().parse::<u32>()
+                {
+                    break pid;
+                }
+                sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("pid file should appear");
+
+        task.abort();
+        let _ = task.await;
+
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let status = std::process::Command::new("kill")
+                    .args(["-0", &pid.to_string()])
+                    .status()
+                    .expect("kill -0 should run");
+                if !status.success() {
+                    break;
+                }
+                sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("child should exit after abort");
+
+        let _ = fs::remove_file(pid_file);
+        let _ = fs::remove_file(script);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn login_status_reports_missing_cli() {
+        let status = openai_login_status_for_path("/definitely/missing/codex");
+        assert_eq!(
+            status,
+            NativeAuthStatus {
+                cli_available: false,
+                logged_in: false,
+                detail:
+                    "Install the OpenAI Codex CLI or set ROSIE_OPENAI_CLI to its executable path."
+                        .to_string(),
+            }
+        );
     }
 }

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -97,7 +97,7 @@ pub fn native_openai_model_presets() -> Vec<String> {
 }
 
 fn openai_login_status_for_path(cli_path: &str) -> NativeAuthStatus {
-    let output = Command::new(&cli_path)
+    let output = Command::new(cli_path)
         .args(["login", "status"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -639,9 +639,7 @@ exit 1
             .await
             .expect_err("logged out provider should fail");
 
-        assert!(err
-            .to_string()
-            .contains("Run `rosie auth login openai`"));
+        assert!(err.to_string().contains("Run `rosie auth login openai`"));
         let _ = fs::remove_file(script);
     }
 
@@ -652,7 +650,8 @@ exit 1
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos();
-        let pid_file = env::temp_dir().join(format!("rosie-openai-pid-{}-{nanos}", std::process::id()));
+        let pid_file =
+            env::temp_dir().join(format!("rosie-openai-pid-{}-{nanos}", std::process::id()));
         let script = write_fake_cli(&format!(
             r#"#!/bin/sh
 if [ "$1" = "login" ] && [ "$2" = "status" ]; then

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3,6 +3,7 @@ use crate::provider::{
     ChatRequest as ProviderChatRequest, Message as ProviderMessage, ProviderEvent, ProviderRouter,
     Role as ProviderRole,
 };
+use crate::providers::openai::native_openai_model_presets;
 use crate::theme::{ThemePalette, config_dir_from_env, discover_config_theme_names, resolve_theme};
 use anyhow::{Result, anyhow};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -847,6 +848,13 @@ fn handle_model_select_input(app: &mut AppState, key: KeyEvent) -> bool {
             app.mode = primary_mode_for_app(app);
             app.status_message = "Model picker cancelled.".to_string();
         }
+        KeyCode::Char('i') => enter_manual_model_entry_with_status(
+            app,
+            format!(
+                "Preset list open for {}. Type a model name and press Enter to apply it.",
+                app.provider_name
+            ),
+        ),
         KeyCode::Char('j') | KeyCode::Down => {
             if !app.model_options.is_empty() {
                 app.model_selected_index =
@@ -1436,7 +1444,7 @@ fn render_modal(frame: &mut ratatui::Frame<'_>, app: &mut AppState, theme: Theme
         } else if app.model_options.is_empty() {
             rows.push(format!("No models available from {}.", app.provider_name));
         } else {
-            rows.push("Select a model (Enter to apply):".to_string());
+            rows.push("Select a model (Enter to apply, i for manual entry):".to_string());
             rows.push(String::new());
             for (idx, model) in app.model_options.iter().enumerate() {
                 let marker = if idx == app.model_selected_index {
@@ -2521,6 +2529,10 @@ fn open_model_picker(app: &mut AppState) {
         return;
     }
 
+    if apply_provider_model_presets(app) {
+        return;
+    }
+
     match provider_supports_model_discovery(&app.config) {
         Ok(true) => {}
         Ok(false) => {
@@ -2556,6 +2568,32 @@ fn open_model_picker(app: &mut AppState) {
         receiver: rx,
         handle,
     });
+}
+
+fn apply_provider_model_presets(app: &mut AppState) -> bool {
+    let Ok((_, provider)) = app.config.active_provider_entry() else {
+        return false;
+    };
+
+    let presets = match provider {
+        ProviderConfig::OpenAi { .. } => native_openai_model_presets(),
+        _ => return false,
+    };
+
+    app.model_options = presets;
+    app.model_loading = false;
+    app.model_manual_entry = false;
+    app.model_input.clear();
+    app.model_selected_index = app
+        .model_options
+        .iter()
+        .position(|name| name == &app.model)
+        .unwrap_or(0);
+    app.status_message = format!(
+        "Loaded {} built-in model preset(s). Press i for manual entry.",
+        app.model_options.len()
+    );
+    true
 }
 
 const MODEL_CACHE_TTL_SECS: i64 = 60;
@@ -4048,10 +4086,7 @@ fn provider_cache_key(config: &StoredConfig) -> Result<String> {
     let (provider_name, provider) = config.active_provider_entry()?;
     let key = match provider {
         ProviderConfig::Ollama { endpoint, .. } => format!("{provider_name}:{endpoint}"),
-        ProviderConfig::OpenAi { endpoint, .. } => format!(
-            "{provider_name}:{}",
-            endpoint.as_deref().unwrap_or("https://api.openai.com/v1")
-        ),
+        ProviderConfig::OpenAi { .. } => format!("{provider_name}:native"),
         ProviderConfig::Anthropic { endpoint, .. } => format!(
             "{provider_name}:{}",
             endpoint
@@ -4064,15 +4099,22 @@ fn provider_cache_key(config: &StoredConfig) -> Result<String> {
 }
 
 fn enter_manual_model_entry(app: &mut AppState) {
+    enter_manual_model_entry_with_status(
+        app,
+        format!(
+            "Model discovery isn't available for {}. Type a model name to continue.",
+            app.provider_name
+        ),
+    );
+}
+
+fn enter_manual_model_entry_with_status(app: &mut AppState, status_message: String) {
     app.model_loading = false;
     app.model_manual_entry = true;
     app.model_options.clear();
     app.model_selected_index = 0;
     app.model_input = app.model.clone();
-    app.status_message = format!(
-        "Model discovery isn't available for {}. Type a model name to continue.",
-        app.provider_name
-    );
+    app.status_message = status_message;
 }
 
 fn normalize_generated_title(raw: &str) -> String {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -62,6 +62,24 @@ fn anthropic_config() -> StoredConfig {
     }
 }
 
+fn native_openai_config() -> StoredConfig {
+    let mut providers = BTreeMap::new();
+    providers.insert(
+        "openai".to_string(),
+        ProviderConfig::OpenAi {
+            model: Some("gpt-5".to_string()),
+            endpoint: None,
+        },
+    );
+
+    StoredConfig {
+        active_provider: Some("openai".to_string()),
+        providers,
+        theme: None,
+        execution_enabled: Some(true),
+    }
+}
+
 fn line_text(line: &Line<'_>) -> String {
     line.spans
         .iter()
@@ -177,6 +195,68 @@ async fn open_model_picker_uses_manual_entry_when_discovery_is_unavailable() {
         assert_eq!(
             app.status_message,
             "Model discovery isn't available for anthropic. Type a model name to continue."
+        );
+    }
+
+    let _ = fs::remove_file(&db_path);
+}
+
+#[tokio::test]
+async fn open_model_picker_uses_native_openai_presets() {
+    let db_path = temp_db_path("model-picker-openai-presets");
+
+    {
+        let store = SessionStore::open(&db_path).expect("open");
+        let loaded = store.load_or_create_active_session().expect("load");
+        let mut app = build_app_from_store(store, loaded.session_id, loaded.messages);
+        app.config = native_openai_config();
+        app.provider_name = "openai".to_string();
+        app.model = "gpt-5".to_string();
+
+        open_model_picker(&mut app);
+
+        assert_eq!(app.mode, InputMode::ModelSelect);
+        assert!(!app.model_manual_entry);
+        assert!(!app.model_loading);
+        assert_eq!(app.model_selected_index, 1);
+        assert_eq!(
+            app.model_options,
+            vec!["gpt-5-codex".to_string(), "gpt-5".to_string()]
+        );
+        assert_eq!(
+            app.status_message,
+            "Loaded 2 built-in model preset(s). Press i for manual entry."
+        );
+    }
+
+    let _ = fs::remove_file(&db_path);
+}
+
+#[test]
+fn model_picker_can_switch_from_presets_to_manual_entry() {
+    let db_path = temp_db_path("model-picker-openai-manual-switch");
+
+    {
+        let store = SessionStore::open(&db_path).expect("open");
+        let loaded = store.load_or_create_active_session().expect("load");
+        let mut app = build_app_from_store(store, loaded.session_id, loaded.messages);
+        app.config = native_openai_config();
+        app.provider_name = "openai".to_string();
+        app.model = "gpt-5".to_string();
+        app.mode = InputMode::ModelSelect;
+        app.model_options = vec!["gpt-5".to_string(), "gpt-5-mini".to_string()];
+
+        handle_model_select_input(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+        );
+
+        assert!(app.model_manual_entry);
+        assert!(app.model_options.is_empty());
+        assert_eq!(app.model_input, "gpt-5");
+        assert_eq!(
+            app.status_message,
+            "Preset list open for openai. Type a model name and press Enter to apply it."
         );
     }
 


### PR DESCRIPTION
Add native codex provider. Use `rosie auth login` instead of `add` for openai.